### PR TITLE
Added a dummy file in wwwroot folder so that it get be cloned.

### DIFF
--- a/source/AspNet5Host/src/IdentityServer3/wwwroot/dummy.txt
+++ b/source/AspNet5Host/src/IdentityServer3/wwwroot/dummy.txt
@@ -1,0 +1,1 @@
+"A place holder file so that this directory gets cloned from Git" 


### PR DESCRIPTION
When the apsnet 5 sample is cloned it does not immediately build as an error complains that the wwwroot directory is missing. The simple fix is to have a dummy file in there so the directory can be cloned.