### PR TITLE
The EntityFramwork sample does not build, there is no build00129 package available

### DIFF
--- a/source/EntityFramework/SelfHost/EntityFramework.csproj
+++ b/source/EntityFramework/SelfHost/EntityFramework.csproj
@@ -73,13 +73,13 @@
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.identitymodel.services" />
     <Reference Include="System.Web" />
-    <Reference Include="Thinktecture.IdentityServer3, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Thinktecture.IdentityServer3.1.2.2-build00129\lib\net45\Thinktecture.IdentityServer3.dll</HintPath>
+    <Reference Include="Thinktecture.IdentityServer3, Version=1.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Thinktecture.IdentityServer3.1.4.2\lib\net45\Thinktecture.IdentityServer3.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Thinktecture.IdentityServer3.EntityFramework, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Thinktecture.IdentityServer3.EntityFramework.1.2.1-build00009\lib\net45\Thinktecture.IdentityServer3.EntityFramework.dll</HintPath>
+      <HintPath>..\packages\Thinktecture.IdentityServer3.EntityFramework.1.2.1\lib\net45\Thinktecture.IdentityServer3.EntityFramework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/source/EntityFramework/SelfHost/packages.config
+++ b/source/EntityFramework/SelfHost/packages.config
@@ -7,6 +7,6 @@
   <package id="Microsoft.Owin.Hosting" version="3.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="Thinktecture.IdentityServer3" version="1.2.2-build00129" targetFramework="net45" />
-  <package id="Thinktecture.IdentityServer3.EntityFramework" version="1.2.1-build00009" targetFramework="net45" />
+  <package id="Thinktecture.IdentityServer3" version="1.4.2" targetFramework="net45" />
+  <package id="Thinktecture.IdentityServer3.EntityFramework" version="1.2.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The submitted pull request fixes this problem by changing to the latest available package on Nuget.