### PR TITLE
Sample didn't work because NuGet dependency didn't exist anymore. Cha…

### DIFF
--- a/source/AspNetIdentity/SelfHost/UserService-AspNetIdentity.csproj
+++ b/source/AspNetIdentity/SelfHost/UserService-AspNetIdentity.csproj
@@ -40,15 +40,17 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\EntityFramework.6.1.2\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
-    <Reference Include="IdentityManager">
-      <HintPath>..\packages\IdentityManager.1.0.0-pre-10032\lib\net45\IdentityManager.dll</HintPath>
+    <Reference Include="IdentityManager, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IdentityManager.1.0.0-beta5-5\lib\net45\IdentityManager.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="IdentityManager.AspNetIdentity">
-      <HintPath>..\packages\IdentityManager.AspNetIdentity.1.0.0-beta4-1\lib\net45\IdentityManager.AspNetIdentity.dll</HintPath>
+    <Reference Include="IdentityManager.AspNetIdentity, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IdentityManager.AspNetIdentity.1.0.0-beta5-1\lib\net45\IdentityManager.AspNetIdentity.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.1.0\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.1\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.AspNet.Identity.EntityFramework, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -97,16 +99,16 @@
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Web" />
     <Reference Include="Thinktecture.IdentityModel.Core, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Thinktecture.IdentityModel.Core.1.3.0\lib\net45\Thinktecture.IdentityModel.Core.dll</HintPath>
+      <HintPath>..\packages\Thinktecture.IdentityModel.Core.1.4.0\lib\net45\Thinktecture.IdentityModel.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Thinktecture.IdentityServer3, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Thinktecture.IdentityServer3.1.2.2-build00129\lib\net45\Thinktecture.IdentityServer3.dll</HintPath>
+    <Reference Include="Thinktecture.IdentityServer3, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Thinktecture.IdentityServer3.1.6.2\lib\net45\Thinktecture.IdentityServer3.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Thinktecture.IdentityServer3.AspNetIdentity, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Thinktecture.IdentityServer3.AspNetIdentity.1.0.1-build00005\lib\net45\Thinktecture.IdentityServer3.AspNetIdentity.dll</HintPath>
+      <HintPath>..\packages\Thinktecture.IdentityServer3.AspNetIdentity.1.0.0\lib\net45\Thinktecture.IdentityServer3.AspNetIdentity.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/source/AspNetIdentity/SelfHost/packages.config
+++ b/source/AspNetIdentity/SelfHost/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework" version="6.1.2" targetFramework="net45" />
-  <package id="IdentityManager" version="1.0.0-pre-10032" targetFramework="net45" />
-  <package id="IdentityManager.AspNetIdentity" version="1.0.0-beta4-1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.Identity.Core" version="2.1.0" targetFramework="net45" />
+  <package id="IdentityManager" version="1.0.0-beta5-5" targetFramework="net45" />
+  <package id="IdentityManager.AspNetIdentity" version="1.0.0-beta5-1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.EntityFramework" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.0" targetFramework="net45" />
@@ -15,7 +15,7 @@
   <package id="Microsoft.Owin.Security.Twitter" version="3.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="Thinktecture.IdentityModel.Core" version="1.3.0" targetFramework="net45" />
-  <package id="Thinktecture.IdentityServer3" version="1.2.2-build00129" targetFramework="net45" />
-  <package id="Thinktecture.IdentityServer3.AspNetIdentity" version="1.0.1-build00005" targetFramework="net45" />
+  <package id="Thinktecture.IdentityModel.Core" version="1.4.0" targetFramework="net45" />
+  <package id="Thinktecture.IdentityServer3" version="1.6.2" targetFramework="net45" />
+  <package id="Thinktecture.IdentityServer3.AspNetIdentity" version="1.0.0" targetFramework="net45" />
 </packages>

--- a/source/EntityFramework/SelfHost/EntityFramework.csproj
+++ b/source/EntityFramework/SelfHost/EntityFramework.csproj
@@ -73,13 +73,13 @@
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.identitymodel.services" />
     <Reference Include="System.Web" />
-    <Reference Include="Thinktecture.IdentityServer3, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Thinktecture.IdentityServer3.1.2.2-build00129\lib\net45\Thinktecture.IdentityServer3.dll</HintPath>
+    <Reference Include="Thinktecture.IdentityServer3, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Thinktecture.IdentityServer3.1.6.2\lib\net45\Thinktecture.IdentityServer3.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Thinktecture.IdentityServer3.EntityFramework, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Thinktecture.IdentityServer3.EntityFramework.1.2.1-build00009\lib\net45\Thinktecture.IdentityServer3.EntityFramework.dll</HintPath>
+      <HintPath>..\packages\Thinktecture.IdentityServer3.EntityFramework.1.2.1\lib\net45\Thinktecture.IdentityServer3.EntityFramework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/source/EntityFramework/SelfHost/packages.config
+++ b/source/EntityFramework/SelfHost/packages.config
@@ -7,6 +7,6 @@
   <package id="Microsoft.Owin.Hosting" version="3.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="Thinktecture.IdentityServer3" version="1.2.2-build00129" targetFramework="net45" />
-  <package id="Thinktecture.IdentityServer3.EntityFramework" version="1.2.1-build00009" targetFramework="net45" />
+  <package id="Thinktecture.IdentityServer3" version="1.6.2" targetFramework="net45" />
+  <package id="Thinktecture.IdentityServer3.EntityFramework" version="1.2.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Sample didn't work because NuGet dependency didn't exist anymore. Changed reference Thinktecture.IdentityServer3.EntityFramework from version 1.2.1-build00009 to 1.2.1. Upgraded Thinktecture.IdentityServer3 to latest (1.6.2)