### PR TITLE
Down method missed ClientSecrets column rename.

### DIFF
--- a/source/EntityFramework/SelfHost/Migrations/ClientConfiguration/201508121544453_v2_0_0.cs
+++ b/source/EntityFramework/SelfHost/Migrations/ClientConfiguration/201508121544453_v2_0_0.cs
@@ -26,6 +26,7 @@ namespace SelfHost.Migrations.ClientConfiguration
         public override void Down()
         {
             //AddColumn("dbo.ClientSecrets", "ClientSecretType", c => c.String(maxLength: 250));
+            RenameColumn("dbo.ClientSecrets", "Type", "ClientSecretType");
             //AddColumn("dbo.Clients", "UpdateAccessTokenClaimsOnRefresh", c => c.Boolean(nullable: false));
             RenameColumn("dbo.Clients", "UpdateAccessTokenOnRefresh", "UpdateAccessTokenClaimsOnRefresh");
             DropIndex("dbo.Clients", new[] { "ClientId" });


### PR DESCRIPTION
ClientSecrets 'Type' column renamed to 'ClientSecretType' on down migration.

The erroneous AddColumn was commented out but its RenameColumn replacement was never manually added in.