### PR TITLE
Using IdentityServer3 v2.0.1 instead of v2.0.1-build00181 to fix build

### DIFF
--- a/source/Logging/SelfHost/SelfHost (Minimal).csproj
+++ b/source/Logging/SelfHost/SelfHost (Minimal).csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="IdentityServer3, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IdentityServer3.2.0.1-build00181\lib\net45\IdentityServer3.dll</HintPath>
+      <HintPath>..\packages\IdentityServer3.2.0.1\lib\net45\IdentityServer3.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/source/Logging/SelfHost/packages.config
+++ b/source/Logging/SelfHost/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="IdentityServer3" version="2.0.1-build00181" targetFramework="net45" />
+  <package id="IdentityServer3" version="2.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net45" />


### PR DESCRIPTION
The logging sample currently using IdentityServer3 v2.0.1-build00181 and doesnt build if you dont have access to -build nuget packages