### PR TITLE
Asp.NET 5 Sample Fixups

### DIFF
--- a/source/AspNet5Host/NuGet.config
+++ b/source/AspNet5Host/NuGet.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="NuGet" value="https://nuget.org/api/v2/" />
+  </packageSources>
+</configuration>

--- a/source/AspNet5Host/src/IdentityServerAspNet5/Startup.cs
+++ b/source/AspNet5Host/src/IdentityServerAspNet5/Startup.cs
@@ -31,7 +31,9 @@ namespace IdentityServerAspNet5
                 AuthenticationOptions = new AuthenticationOptions
                 {
                     EnablePostSignOutAutoRedirect = true
-                }
+                },
+
+                RequireSsl = false
             };
 
             app.UseIdentityServer(idsrvOptions);

--- a/source/AspNet5Host/src/IdentityServerAspNet5/Startup.cs
+++ b/source/AspNet5Host/src/IdentityServerAspNet5/Startup.cs
@@ -3,11 +3,27 @@ using Microsoft.Framework.DependencyInjection;
 using System.Security.Cryptography.X509Certificates;
 using IdentityServer3.Core.Configuration;
 using Microsoft.Dnx.Runtime;
+using Microsoft.Framework.Logging;
+using Serilog;
+using System;
 
 namespace IdentityServerAspNet5
 {
     public class Startup
     {
+        public Startup(ILoggerFactory loggerFactory)
+        {
+            var serilogLogger = new LoggerConfiguration()
+                .WriteTo
+                .TextWriter(Console.Out)
+                .MinimumLevel.Verbose()
+                .CreateLogger();
+
+            Log.Logger = serilogLogger;
+            loggerFactory.MinimumLevel = LogLevel.Debug;
+            loggerFactory.AddSerilog(serilogLogger);
+        }
+        
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddDataProtection();

--- a/source/AspNet5Host/src/IdentityServerAspNet5/project.json
+++ b/source/AspNet5Host/src/IdentityServerAspNet5/project.json
@@ -9,6 +9,8 @@
     "Microsoft.Owin": "3.0.1",
     "Microsoft.AspNet.DataProtection": "1.0.0-beta8",
     "Microsoft.AspNet.Owin": "1.0.0-beta8",
+    "Microsoft.Framework.Logging": "1.0.0-beta8",
+    "Serilog.Framework.Logging": "1.0.0-beta8-10065",
     "IdentityServer3": "2.0.2"
   },
 


### PR DESCRIPTION
 - Added NuGet.config to identify the NuGet sources.
 - Doesn't require SSL for ASP.NET 5 sample. I am not aware of any easy way to have HTTPS binding set in all platforms when you run the sample. So, I just disabled this for the sample to work. May not be the desired behaviour though :disappointed: One alternative would be to provide some scripts to run for each platform to set this up and add the info to Readme.