### PR TITLE
Update UserService.cs class in the Example

### DIFF
--- a/source/AspNetIdentity/WebHost/IdSvr/UserService.cs
+++ b/source/AspNetIdentity/WebHost/IdSvr/UserService.cs
@@ -43,5 +43,17 @@ namespace WebHost.IdSvr
             : base(userMgr)
         {
         }
+        
+        protected override async Task<IEnumerable<System.Security.Claims.Claim>> GetClaimsFromAccount(User user) {
+            var claims = (await base.GetClaimsFromAccount(user)).ToList();
+			if (!String.IsNullOrWhiteSpace(user.FirstName)) {
+				claims.Add(new Claim("given_name", user.FirstName));
+			}
+			if (!String.IsNullOrWhiteSpace(user.LastName)) {
+				claims.Add(new Claim("family_name", user.LastName));
+			}
+			
+			return claims;
+        }
     }
 }


### PR DESCRIPTION
The class User (implemented in SimpleEntities.cs) extend IdentityUser by adding FirstName and LastName. Anyway these properties are never transferred as Claims to the clients. By overriding GetClaimsFromAccount I just add the proper Claims.

This way the example is more complete: the flow of information representing the "given_name" and "family_name" goes now from ASP.NET Identity to clients