### PR TITLE
Fix using portable directory separator character

### DIFF
--- a/source/AspNet5/src/IdentityServer/Startup.cs
+++ b/source/AspNet5/src/IdentityServer/Startup.cs
@@ -30,7 +30,7 @@ namespace IdentityServer
             app.UseIISPlatformHandler();
             
 
-            var certFile = env.ApplicationBasePath + "\\idsrv3test.pfx";
+            var certFile = env.ApplicationBasePath + $"{System.IO.Path.DirectorySeparatorChar}idsrv3test.pfx";
 
             var idsrvOptions = new IdentityServerOptions
             {


### PR DESCRIPTION
fixed directory separator character using portable char to make it work in unix environment too.