### PR TITLE
Compile error for outdated references

### DIFF
--- a/source/MembershipReboot/NuGet.config
+++ b/source/MembershipReboot/NuGet.config
@@ -1,10 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <activePackageSource>
+    <add key="All" value="(Aggregate source)" />
+  </activePackageSource>
   <packageSources>
     <add key="Identity* Dev Feed" value="https://www.myget.org/F/identity/" />
     <add key="Nuget" value="https://www.nuget.org/api/v2/" />
   </packageSources>
-  <activePackageSource>
-    <add key="All" value="(Aggregate source)" />
-  </activePackageSource>
 </configuration>

--- a/source/MembershipReboot/WebHost/WebHost.csproj
+++ b/source/MembershipReboot/WebHost/WebHost.csproj
@@ -67,8 +67,8 @@
       <HintPath>..\packages\IdentityModel.1.0.0\lib\net45\IdentityModel.Net45.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="IdentityServer3, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\IdentityServer3.2.4.0\lib\net45\IdentityServer3.dll</HintPath>
+    <Reference Include="IdentityServer3, Version=2.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IdentityServer3.2.5.0\lib\net45\IdentityServer3.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/source/MembershipReboot/WebHost/packages.config
+++ b/source/MembershipReboot/WebHost/packages.config
@@ -6,7 +6,7 @@
   <package id="IdentityManager" version="1.0.0-beta5-5" targetFramework="net45" />
   <package id="IdentityManager.MembershipReboot" version="1.0.0-beta5-1" targetFramework="net45" />
   <package id="IdentityModel" version="1.0.0" targetFramework="net45" />
-  <package id="IdentityServer3" version="2.4.0" targetFramework="net45" />
+  <package id="IdentityServer3" version="2.5.0" targetFramework="net45" />
   <package id="IdentityServer3.MembershipReboot" version="2.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="3.0.1" targetFramework="net45" />


### PR DESCRIPTION
Compile error:  'Client' does not contain a definition for 'AllowAccessTokensViaBrowser' WebHost

Proposed solution:

Updated on this package manager following this order below:

 PM> Uninstall-Package IdentityServer3.MembershipReboot
 PM> Uninstall-Package IdentityManager
 PM> Update-Package IdentityServer3
 PM> Install-Package IdentityManager.MembershipReboot -Pre
 PM> Install-Package BrockAllen.MembershipReboot.Ef -Pre
 PM> Install-Package IdentityServer3.MembershipReboot -Pre

Result:
Build success

Issue: #253