### PR TITLE
Execute AutoRedirect if allowed by client's configuration

### DIFF
--- a/source/MVC ViewService/MvcViewServiceSample/Views/LogonWorkflow/LoggedOut.cshtml
+++ b/source/MVC ViewService/MvcViewServiceSample/Views/LogonWorkflow/LoggedOut.cshtml
@@ -42,6 +42,20 @@
         }
     </div>
 </div>
+
+@if (Model.AutoRedirect && !string.IsNullOrEmpty(Model.RedirectUrl))
+{
+    var autoRedirectDelay = Model.AutoRedirectDelay < 0 ? 0 : Model.AutoRedirectDelay;
+
+    <script>
+        (function() {
+            window.setTimeout(function() {
+                window.location = '@Model.RedirectUrl';
+            }, @autoRedirectDelay * 1000);
+        })();
+    </script>
+}
+
 @section scripts{
     @Html.Partial("_RenderAngularModel")
 }


### PR DESCRIPTION
With the removal of angular and site scripts from MVC views, LoggedOut view lost ability to AutoRedirect when IdentityServer is configured to allow post logout auto redirection.