### PR TITLE
Update app.js to match IdentityServer3 ClientId

### DIFF
--- a/source/Clients/JavaScriptImplicitClient/app.js
+++ b/source/Clients/JavaScriptImplicitClient/app.js
@@ -8,7 +8,7 @@ Oidc.Log.level = Oidc.Log.INFO;
 
 var settings = {
     authority: "https://localhost:44333/core",
-    client_id: "js.usermanager",
+    client_id: "js.tokenmanager",
     redirect_uri: window.location.protocol + "//" + window.location.host + "/index.html",
     post_logout_redirect_uri: window.location.protocol + "//" + window.location.host + "/index.html",
 


### PR DESCRIPTION
@brockallen, I was getting "The client application is not known or is not authorized" errors without this fix.

Updated client_id to match ClientId on line 195 of Client.cs in Host.Configuration/Config/Clients.cs (commit https://github.com/IdentityServer/IdentityServer3/commit/df6336ba98f338aaeb523a03148be48e2155d0fa)