### PR TITLE
No claims without Authorize attribute

### DIFF
--- a/source/Clients/MVC OWIN Client (Hybrid)/Controllers/HomeController.cs
+++ b/source/Clients/MVC OWIN Client (Hybrid)/Controllers/HomeController.cs
@@ -27,6 +27,7 @@ namespace MVC_OWIN_Client.Controllers
             return View();
         }
 
+        [Authorize]
         public async Task<ActionResult> CallApi()
         {
             var token = (User as ClaimsPrincipal).FindFirst("access_token").Value;


### PR DESCRIPTION
Without [Authorize] attribute before CallApi we get null exception on claims.